### PR TITLE
Fix sytax error resolve #11

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -303,7 +303,7 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     plugins: options.plugins,
   });
 
-  return {body: parsed.body dependencies: parsed.dependencies};
+  return {body: parsed.body, dependencies: parsed.dependencies};
 };
 
 /**


### PR DESCRIPTION
Corrected a syntax error on the return object from the compileClientWithDependenciesTracked function. There was a missing comma separating the properties.